### PR TITLE
Fix compile error re: 128bit cast

### DIFF
--- a/clauseRAM.h
+++ b/clauseRAM.h
@@ -106,7 +106,7 @@ public:
             Integer h = getHash(access_record[i].second);
             block v, m;
             hash_and_mac(v, m, access_record[i].first, h);
-            HRecord.push_back((__uint128_t)v);
+            HRecord.emplace_back((__uint128_t)v);
             HRecord_mac.push_back(m);
         }
 
@@ -120,7 +120,7 @@ public:
             sorted_hash_value.push_back(h);
             block v, m;
             hash_and_mac(v, m, sorted_index[i], h);
-            sorted_HRecord.push_back((__uint128_t)v);
+            sorted_HRecord.emplace_back((__uint128_t)v);
             sorted_HRecord_mac.push_back(m);
         }
 


### PR DESCRIPTION
Recall that `(__uint128_t)v` has type `__int128 unsigned&&`.

After C++20, `std::vector::push_back` cannot take an rvalue reference[1]. My version of g++ (12.2.1) has already transitioned.

This patch uses `std::vector::emplace_back`.

[1]: https://en.cppreference.com/w/cpp/container/vector/push_back